### PR TITLE
Fix skip_string_normalization (lack of) inversion

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -86,7 +86,7 @@ def index():
             "target_versions": black.PY36_VERSIONS if py36 else set(),
             "line_length": line_length,
             "is_pyi": pyi,
-            "string_normalization": skip_string_normalization
+            "string_normalization": not skip_string_normalization
         },
     )
 


### PR DESCRIPTION
black.FileMode requires `string_normalization=False` to disable the default string normalization behaviour. Currently the inverse of this is provided.

Fixes #15