### PR TITLE
Fix result not being returned to the client

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -64,6 +64,8 @@ def format_code(source, fast, configuration):
     try:
         mode = black.FileMode(**configuration)
         formatted = black.format_file_contents(source, fast=fast, mode=mode)
+    except black.NothingChanged:
+        formatted = source
     except Exception as exc:
         formatted = normalize_exception(exc)
 


### PR DESCRIPTION
Fixes psf/black#1720.

### Commit message
commit 7a81bc1f9c5dff342e01ec52734a1c493f7a004e changed the web app to
start using `black.format_file_contents` instead of `black.format_str`.
The problem was that `black.format_file_contents` raises `black.NothingChanged`
for when the input is the same as the result. `black.format_str` just returns
the formatted code regardless if it is different from the original code.
The error handling logic in `format_code` wasn't updated to properly
handle NothingChanged exceptions so when a NothingChanged exception was
raised, the web app incorrectly assumed the code failed to format and
tried to return the normalized error message.